### PR TITLE
Added back arrow to 'Quiz' and 'About app' activities

### DIFF
--- a/app/src/main/java/com/example/android/miwok/AboutApplication.java
+++ b/app/src/main/java/com/example/android/miwok/AboutApplication.java
@@ -14,6 +14,6 @@ public class AboutApplication extends AppCompatActivity{
         // this is for the arrow in the menu bar to go back to parent activity
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 }

--- a/app/src/main/java/com/example/android/miwok/QuizActivity.java
+++ b/app/src/main/java/com/example/android/miwok/QuizActivity.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
             // this is for the arrow in the menu bar to go back to parent activity
             Toolbar toolbar = findViewById(R.id.toolbar);
             setSupportActionBar(toolbar);
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
             // Find views
             scrollView = findViewById(R.id.scrollView);
             // Question 1

--- a/app/src/main/res/layout/activity_quiz.xml
+++ b/app/src/main/res/layout/activity_quiz.xml
@@ -12,14 +12,13 @@
         android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar">
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-            app:titleTextColor="@color/text_color_heading_white"
             app:layout_scrollFlags="scroll|enterAlways|snap" />
 
         <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
I changed android:theme from `"@style/ThemeOverlay.AppCompat.ActionBar"` to `"@style/ThemeOverlay.AppCompat.Dark.ActionBar"` because with previous theme back arrow was black. This also changed radio button tint initial color from black to white. It's not good but I think it's better than white title and black arrow side-by-side. 
I think we can create separate issue and groom all colors and styles in app. Or we can solve it in issue about material design guidelines. What do you think?
Or you can reject this pull request and I'll fix it here :)